### PR TITLE
Add 'ignore' feature when building contact matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,20 @@ env:
 python:
   - '3.6'
 
-cache:
-  - pip
-  - conda
+cache: 
+   directories: 
+     - $HOME/download 
+     - $HOME/miniconda 
+  
+ before_cache: 
+ - if ! [[ $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi 
+ - rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history 
+
+#cache:
+  #directories:
+    #- $HOME/miniconda/envs/mdstates
+  #- pip
+  #- conda
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
      - $HOME/download 
      - $HOME/miniconda 
   
- before_cache: 
- - if ! [[ $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi 
- - rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history 
+before_cache: 
+  - if ! [[ $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi 
+  - rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history 
 
 #cache:
   #directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,6 @@ env:
 python:
   - '3.6'
 
-cache: 
-   directories: 
-     - $HOME/download 
-     - $HOME/miniconda 
-  
-before_cache: 
-  - if ! [[ $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi 
-  - rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history 
-
-#cache:
-  #directories:
-    #- $HOME/miniconda/envs/mdstates
-  #- pip
-  #- conda
-
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
 python:
   - '3.6'
 
+cache:
+  - pip
+  - conda
+
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -454,7 +454,7 @@ class Network:
         if rep_id == -1 and args:
             smiles_list = args[0]
         else:
-            assert not self.replica[rep_id]['smiles'], "SMILES list is empty."
+            assert self.replica[rep_id]['smiles'], "SMILES list is empty."
             smiles_list = self.replica[rep_id]['smiles']
 
         chem_eq_list = []

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -81,10 +81,6 @@ class Network:
             If the trajectory path matches a previously loaded replica.
         """
         if len(self.replica) > 0:
-#             assert self.replica[-1]['traj'].topology ==\
-#                 md.load(topology).topology,\
-#                 "All topologies must be the same."
-
             for rep in self.replica:
                 assert rep['path'] != abspath(trajectory),\
                     "A trajectory from that location is already loaded."
@@ -204,9 +200,9 @@ class Network:
             elif isinstance(ignore, list):
                 for atom in ignore:
                     if isinstance(atom, str):
-                        sym_ignore_list.append([idx for idx, atom in
-                                                enumerate(self.atoms)
-                                                if atom == atom_sym])
+                        sym_ignore_list = [idx for idx, at in
+                                           enumerate(self.atoms)
+                                           if at == atom]
                         for atom_id in sym_ignore_list:
                             ignore_list.append(atom_id)
                     elif isinstance(atom, Number):

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -70,6 +70,13 @@ def test_generate_contact_matrix():
 
     assert net.replica[0]['cmat'].shape ==\
         (n_frames, net.n_atoms, net.n_atoms)
+    
+    net = Network()
+    net.add_replica(traj_path, top_path)
+    net.generate_contact_matrix(ignore='Cl')
+
+    assert (net.replica[0]['cmat'][:, [4, 5], :] == 0).all() and\
+           (net.replica[0]['cmat'][:, :, [4, 5]] == 0).all()
 
     return
 

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -93,7 +93,7 @@ def test_generate_contact_matrix():
            (net.replica[0]['cmat'][:, :, 4] == 0).all() and\
            (net.replica[0]['cmat'][:, [1, 2, 3], :] == 0).all() and\
            (net.replica[0]['cmat'][:, :, [1, 2, 3]] == 0).all(),\
-           "Ignore feature is not working properly with lists."
+        "Ignore feature is not working properly with lists."
     return
 
 

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -70,10 +70,17 @@ def test_generate_contact_matrix():
 
     assert net.replica[0]['cmat'].shape ==\
         (n_frames, net.n_atoms, net.n_atoms)
-    
+
     net = Network()
     net.add_replica(traj_path, top_path)
     net.generate_contact_matrix(ignore='Cl')
+
+    assert (net.replica[0]['cmat'][:, [4, 5], :] == 0).all() and\
+           (net.replica[0]['cmat'][:, :, [4, 5]] == 0).all()
+
+    net = Network()
+    net.add_replica(traj_path, top_path)
+    net.generate_contact_matrix(ignore=[4, 5])
 
     assert (net.replica[0]['cmat'][:, [4, 5], :] == 0).all() and\
            (net.replica[0]['cmat'][:, :, [4, 5]] == 0).all()

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -85,6 +85,14 @@ def test_generate_contact_matrix():
     assert (net.replica[0]['cmat'][:, [4, 5], :] == 0).all() and\
            (net.replica[0]['cmat'][:, :, [4, 5]] == 0).all()
 
+    net = Network()
+    net.add_replica(traj_path, top_path)
+    net.generate_contact_matrix(ignore=[4, 'H'])
+
+    assert (net.replica[0]['cmat'][:, 4, :] == 0).all() and\
+           (net.replica[0]['cmat'][:, :, 4] == 0).all() and\
+           (net.replica[0]['cmat'][:, [1, 2, 3], :] == 0).all() and\
+           (net.replica[0]['cmat'][:, :, [1, 2, 3]] == 0).all()
     return
 
 

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -92,7 +92,8 @@ def test_generate_contact_matrix():
     assert (net.replica[0]['cmat'][:, 4, :] == 0).all() and\
            (net.replica[0]['cmat'][:, :, 4] == 0).all() and\
            (net.replica[0]['cmat'][:, [1, 2, 3], :] == 0).all() and\
-           (net.replica[0]['cmat'][:, :, [1, 2, 3]] == 0).all()
+           (net.replica[0]['cmat'][:, :, [1, 2, 3]] == 0).all(),\
+           "Ignore feature is not working properly with lists."
     return
 
 


### PR DESCRIPTION
`Network.generate_contact_matrix()` now accepts an ignore feature. This argument can be either a string (i.e. `'Li'`) or a list of str/int (i.e. `['Li', 'H']` or `[0, 4]` or `['Li', 4]`. The strings must be an atomic symbol and all interactions with that element are ignored. If passing `int`, it must be the index of the specific atom to be ignored.