### PR TITLE
Parallelizing trajectory decoding

### DIFF
--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -1,6 +1,7 @@
 from os.path import abspath, dirname, join
 
 import mdtraj as md
+from multiprocessing import Pool
 import networkx as nx
 from networkx.drawing.nx_agraph import to_agraph
 import numpy as np
@@ -225,7 +226,8 @@ class Network:
 
     def decode(self, n=10, states=[0, 1], start_p=[0.5, 0.5],
                trans_p=[[0.999, 0.001], [0.001, 0.999]],
-               emission_p=[[0.60, 0.40], [0.40, 0.60]], min_lifetime=20):
+               emission_p=[[0.60, 0.40], [0.40, 0.60]], min_lifetime=20,
+               cores=28):
         """Uses Viterbi algorithm to clean the signal for each bond.
 
         Prior to processing each individual index in the contact
@@ -275,6 +277,8 @@ class Network:
             if rep['processed']:
                 pass
             else:
+                p = Pool(cores)
+                p.map(viterbi)
                 ignore_list = generate_ignore_list(rep['cmat'], n)
 
                 for i in range(self.n_atoms - 1):

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -291,7 +291,8 @@ class Network:
                                             states, start_p,
                                             trans_p, emission_p)
                             else:
-                                run_indices.append([i, j, rep['cmat'][:, i, j]])
+                                run_indices.append([i, j,
+                                                    rep['cmat'][:, i, j]])
 
                 if cores > 1:
                     p = Pool(cores)

--- a/mdstates/hmm.py
+++ b/mdstates/hmm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-__all__ = ['generate_ignore_list', 'viterbi']
+__all__ = ['generate_ignore_list', 'viterbi', 'viterbi_wrapper']
 
 
 def generate_ignore_list(cmat, n):
@@ -116,6 +116,19 @@ def viterbi(obs, states, start_p, trans_p, emission_p):
         previous = V[t + 1][previous]["prev"]
 
     return optimal_path
+
+
+def viterbi_wrapper(inp_params):
+    states = np.array([0, 1])
+    start_p = np.array([0.5, 0.5])
+    trans_p = np.array([[0.999, 0.001], [0.001, 0.999]])
+    emission_p = np.array([[0.6, 0.4], [0.4, 0.6]])
+
+    i = inp_params[0]
+    j = inp_params[1]
+    obs = inp_params[2]
+
+    return (i, j, viterbi(obs, states, start_p, trans_p, emission_p))
 
 
 def fast_viterbi(obs, states, start_p, trans_p, emission_p):

--- a/mdstates/hmm.py
+++ b/mdstates/hmm.py
@@ -132,7 +132,7 @@ def fast_viterbi(obs, states, start_p, trans_p, emission_p):
     trans_p : list of list of float
         Probabilities of transitioning from one hidden state to
         another.
-    emission_p : list of of list of float
+    emission_p : list of list of float
         Probabilities of emitting an observable given the present
         hidden state.
 
@@ -154,7 +154,7 @@ def fast_viterbi(obs, states, start_p, trans_p, emission_p):
             V[t, st] = max_tr_prob + np.log10(emission_p[st, obs[t]])
             prev_states[t, st] = np.where(V[t - 1, :] +
                                           np.log10(trans_p[:, st]) ==
-                                          max_tr_prob)
+                                          max_tr_prob)[0][0]
 
     optimal_path = np.zeros(len(obs), dtype=int)
 
@@ -162,7 +162,7 @@ def fast_viterbi(obs, states, start_p, trans_p, emission_p):
     max_final_prob = V[-1, :].max()
 
     # Get most probable state and its backtrack.
-    optimal_path[-1] = np.where(V[-1, :] == max_final_prob)
+    optimal_path[-1] = np.where(V[-1, :] == max_final_prob)[0][0]
     previous = optimal_path[-1]
 
     # Follow the each backtrack from the saved paths.


### PR DESCRIPTION
In this PR, the ability to parallelize the decoding of each bond using `multiprocessing`. This was added to `Network.decode()` where `cores` can be set to the number of threads. Setting `cores=1` will result in serial execution.

It still needs to allow different hidden Markov model parameters for the decoding process. Right now, they are set to the defaults and cannot be changed for parallel runs.