### PR TITLE
Checkpointing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 script:
   # Your test script goes here
-  - flake8 --ignore N802,N806,W504 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /doc/`
+  - flake8 --ignore N802,N806,W504,W605 `find . -name \*.py | grep -v setup.py | grep -v version.py | grep -v __init__.py | grep -v /doc/`
   - mkdir for_test
   - cd for_test
   - py.test --pyargs mdstates --cov-report term-missing --cov=mdstates

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -940,6 +940,12 @@ class Network:
         name : str
             Name of the checkpoint file.
         """
+        for i, rep in enumerate(self.replica):
+            if rep['smiles']:
+                pass
+            else:
+                rep['smiles'] = self._generate_SMILES(i, tol=10)
+
         with open(name + '.txt', 'w') as f:
             f.write('{}\n'.format(self._first_smiles))
             for i, rep in enumerate(self.replica):

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -949,3 +949,28 @@ class Network:
         topology_path = join(parent_dir, top_name)
         mol.write('pdb', topology_path, overwrite=True)
         return topology_path
+
+    def save(self, name):
+        """Saves the current state of the reaction network as a txt.
+
+        This saves the SMILES list and frames that each SMILES state
+        is associated with in a text file.
+
+        Parameters
+        ----------
+        name : str
+            Name of the checkpoint file.
+        """
+
+        return
+
+    def load(self, name):
+        """Loads the network from a checkpoint file.
+
+        Parameters
+        ----------
+        name : str
+            Path to the checkpoint file.
+        """
+
+        return

--- a/mdstates/core.py
+++ b/mdstates/core.py
@@ -971,7 +971,6 @@ class Network:
         name : str
             Path to the checkpoint file.
         """
-        num_reps = 0
         with open(name, 'r') as f:
             self._first_smiles = f.readline().strip('\n')
             for line in f.readlines():
@@ -988,7 +987,6 @@ class Network:
                     else:
                         self.replica[rep_id]['smiles'] = []
                     self.replica[rep_id]['smiles'].append((data[0], data[1]))
-                
         return
 
     def build_from_load(self, filename='overall.png', exclude=[],

--- a/mdstates/tests/test_cases/test_load.txt
+++ b/mdstates/tests/test_cases/test_load.txt
@@ -1,0 +1,8 @@
+replica0
+CCl.[F-],1
+CF.[Cl-],100
+CCl.[F-],200
+replica1
+CCl.[F-],1
+CF.[Cl-],300
+CCl.[F-],500

--- a/mdstates/tests/test_cases/test_load.txt
+++ b/mdstates/tests/test_cases/test_load.txt
@@ -1,3 +1,4 @@
+CCl.[F-]
 replica0
 CCl.[F-],1
 CF.[Cl-],100

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -318,3 +318,29 @@ def test_compile_networks():
 def test_build_all_networks():
     pass
     return
+
+def test_save():
+    net = Network()
+    net.add_replica(traj_path, top_path)
+    net.generate_contact_matrix()
+    net.decode()
+    net.save('test')
+    if os.path.exists('test.txt'):
+        os.remove('test.txt')
+    else:
+        raise AssertionError('Checkpont file not saved.')
+    return
+
+def test_load():
+    net = Network()
+    test_file = os.path.join(currentdir, 'test_cases', 'test_load.txt')
+    net.load(test_file)
+
+    assert len(net.replica) == 2
+    assert net.replica[0]['smiles'] = [('CCl.[F-]', 1),
+                                       ('CF.[Cl-]', 100),
+                                       ('CCl.[F-]', 200)]
+    assert net.replica[1]['smiles'] = [('CCl.[F-]', 1),
+                                       ('CF.[Cl-]', 300),
+                                       ('CCl.[F-]', 500)]
+    return

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -7,7 +7,7 @@ import numpy as np
 import networkx as nx
 
 from ..core import Network
-from ..graphs import prepare_graph
+# from ..graphs import prepare_graph
 
 currentdir = os.path.dirname(__file__)
 testdir = os.path.join(currentdir, 'test_cases')
@@ -336,6 +336,7 @@ def test_build_all_networks():
     pass
     return
 
+
 def test_save():
     net = Network()
     net.add_replica(traj_path, top_path)
@@ -348,6 +349,7 @@ def test_save():
     else:
         raise AssertionError('Checkpont file not saved.')
     return
+
 
 def test_load():
     net = Network()

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -340,6 +340,7 @@ def test_save():
     net.add_replica(traj_path, top_path)
     net.generate_contact_matrix()
     net.decode()
+    net._build_all_networks()
     net.save('test')
     if os.path.exists('test.txt'):
         os.remove('test.txt')
@@ -350,13 +351,14 @@ def test_save():
 def test_load():
     net = Network()
     test_file = os.path.join(currentdir, 'test_cases', 'test_load.txt')
+    print(test_file)
     net.load(test_file)
 
     assert len(net.replica) == 2
-    assert net.replica[0]['smiles'] = [('CCl.[F-]', 1),
-                                       ('CF.[Cl-]', 100),
-                                       ('CCl.[F-]', 200)]
-    assert net.replica[1]['smiles'] = [('CCl.[F-]', 1),
-                                       ('CF.[Cl-]', 300),
-                                       ('CCl.[F-]', 500)]
+    assert net.replica[0]['smiles'] == [('CCl.[F-]', 1),
+                                        ('CF.[Cl-]', 100),
+                                        ('CCl.[F-]', 200)]
+    assert net.replica[1]['smiles'] == [('CCl.[F-]', 1),
+                                        ('CF.[Cl-]', 300),
+                                        ('CCl.[F-]', 500)]
     return

--- a/mdstates/tests/test_core.py
+++ b/mdstates/tests/test_core.py
@@ -7,6 +7,7 @@ import numpy as np
 import networkx as nx
 
 from ..core import Network
+from ..graphs import prepare_graph
 
 currentdir = os.path.dirname(__file__)
 testdir = os.path.join(currentdir, 'test_cases')
@@ -351,7 +352,6 @@ def test_save():
 def test_load():
     net = Network()
     test_file = os.path.join(currentdir, 'test_cases', 'test_load.txt')
-    print(test_file)
     net.load(test_file)
 
     assert len(net.replica) == 2
@@ -361,4 +361,10 @@ def test_load():
     assert net.replica[1]['smiles'] == [('CCl.[F-]', 1),
                                         ('CF.[Cl-]', 300),
                                         ('CCl.[F-]', 500)]
+    for rep in net.replica:
+        rep['network'] = net._build_network(rep['smiles'])
+
+    compiled = net._compile_networks()
+    net.network = compiled
+    final = prepare_graph(net.network, root_node=net._first_smiles)
     return


### PR DESCRIPTION
This PR adds the ability to save the state of network after it has been processed and decoded. It saves the SMILES list for each replica. This file can then be loaded back into a new `Network()` instance and then the network can be visualized appropriately.